### PR TITLE
Use UUID identifiers for orders and payments

### DIFF
--- a/services/order-service/src/main/java/com/rafael/api/controller/OrderController.java
+++ b/services/order-service/src/main/java/com/rafael/api/controller/OrderController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +32,7 @@ public class OrderController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<OrderResponse> getById(@PathVariable("id") Long id) {
+    public ResponseEntity<OrderResponse> getById(@PathVariable("id") UUID id) {
         OrderResponse order = service.getById(id);
         return ResponseEntity.status(HttpStatus.CREATED).body(order);
     }

--- a/services/order-service/src/main/java/com/rafael/domain/repository/OrderRepository.java
+++ b/services/order-service/src/main/java/com/rafael/domain/repository/OrderRepository.java
@@ -3,5 +3,7 @@ package com.rafael.domain.repository;
 import com.rafael.domain.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
 }

--- a/services/order-service/src/main/java/com/rafael/service/OrderService.java
+++ b/services/order-service/src/main/java/com/rafael/service/OrderService.java
@@ -75,7 +75,7 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public OrderResponse getById(Long id) {
+    public OrderResponse getById(UUID id) {
         Order orderResponse = repository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Ordem não encontrada: " + id));
         return new OrderResponse(

--- a/services/payment-service/src/main/java/com/rafael/domain/repository/PaymentRepository.java
+++ b/services/payment-service/src/main/java/com/rafael/domain/repository/PaymentRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface PaymentRepository extends JpaRepository<Payment, Long> {
+public interface PaymentRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findTopByOrderIdOrderByCreatedAtDesc(UUID orderId);
 }


### PR DESCRIPTION
## Summary
- Refactor order service to use `UUID` as repository key and API parameter types
- Switch payment repository to `UUID` identifiers for entity management

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*
- `mvn -q test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af41a845c08320802d5c42db834d60