### PR TITLE
Remove item id from order creation request

### DIFF
--- a/services/order-service/src/main/java/com/rafael/api/request/CreateOrderRequest.java
+++ b/services/order-service/src/main/java/com/rafael/api/request/CreateOrderRequest.java
@@ -12,9 +12,8 @@ public record CreateOrderRequest(
         @NotNull PaymentMethod paymentMethod
 ) {
     public record Item(
-            @NotNull UUID id,
             @NotBlank String name,
             @Min(1) int quantity,
-            @DecimalMin("0.00") Double unitPrice
+            @DecimalMin("0.00") Double price
     ) {}
 }

--- a/services/order-service/src/main/java/com/rafael/service/OrderService.java
+++ b/services/order-service/src/main/java/com/rafael/service/OrderService.java
@@ -12,9 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.UUID;
 
 
 @Slf4j
@@ -30,7 +28,7 @@ public class OrderService {
         log.info("Criando nova ordem de compra!");
 
         var items = request.items().stream()
-                .map(i -> new OrderItem(i.name(), i.unitPrice(), i.quantity()))
+                .map(i -> new OrderItem(i.name(), i.price(), i.quantity()))
                 .toList();
 
         var order = new Order(items, request.customerId(), request.paymentMethod());


### PR DESCRIPTION
## Summary
- simplify item payload by removing id and using name, quantity, price
- adapt order creation service to new item structure

## Testing
- `mvn -q -f services/order-service/pom.xml test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af442999188320b977277f1dd6fb6c