### PR TITLE
chore: remove unused imports

### DIFF
--- a/services/order-service/src/main/java/com/rafael/messaging/OrderEventProducer.java
+++ b/services/order-service/src/main/java/com/rafael/messaging/OrderEventProducer.java
@@ -1,11 +1,8 @@
 package com.rafael.messaging;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
-
-import java.io.Serializable;
 
 @RequiredArgsConstructor
 @Component


### PR DESCRIPTION
## Summary
- clean up unused imports in `OrderEventProducer`

## Testing
- `mvn formatter:format` *(fails: Non-resolvable parent POM)*
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68af442e2ea08320a9b0a3242f134b71