### PR TITLE
Refactor order entities to rely on UUID generator

### DIFF
--- a/services/order-service/src/main/java/com/rafael/domain/model/Order.java
+++ b/services/order-service/src/main/java/com/rafael/domain/model/Order.java
@@ -12,15 +12,13 @@ import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
-import static java.lang.System.currentTimeMillis;
-
-@Entity @Table(name="orders")
+@Entity
+@Table(name = "orders")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Order {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue
     @UuidGenerator
     @JdbcTypeCode(SqlTypes.UUID)
     private UUID id;

--- a/services/order-service/src/main/java/com/rafael/domain/model/OrderItem.java
+++ b/services/order-service/src/main/java/com/rafael/domain/model/OrderItem.java
@@ -9,11 +9,10 @@ import org.hibernate.type.SqlTypes;
 import java.util.UUID;
 
 @Entity
-@Table(name="order_items")
+@Table(name = "order_items")
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class OrderItem {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- Drop unused `@AllArgsConstructor` and `currentTimeMillis` import in `Order`
- Remove identity strategy so `Order` IDs rely on `@UuidGenerator`
- Remove redundant `@AllArgsConstructor` from `OrderItem`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af4432c50c8320a03262cf17fc09c7