### PR TITLE
Add payment status mutation methods

### DIFF
--- a/services/payment-service/src/main/java/com/rafael/domain/model/Payment.java
+++ b/services/payment-service/src/main/java/com/rafael/domain/model/Payment.java
@@ -57,6 +57,9 @@ public class Payment {
     public boolean isAuthorized() { return status == PaymentStatus.AUTHORIZED; }
     public boolean isFailed()     { return status == PaymentStatus.FAILED; }
 
+    public void markAuthorized() { this.status = PaymentStatus.AUTHORIZED; }
+    public void markFailed()     { this.status = PaymentStatus.FAILED; }
+
     public static Payment createPending(UUID orderId,
                                         Double amount,
                                         PaymentMethod method) {

--- a/services/payment-service/src/main/java/com/rafael/service/PaymentService.java
+++ b/services/payment-service/src/main/java/com/rafael/service/PaymentService.java
@@ -27,12 +27,6 @@ public class PaymentService {
     public void process(UUID orderId, Double amount, PaymentMethod method) {
         log.info("Iniciando processamento do pagamento. orderId={}, amount={}, method={}", orderId, amount, method);
 
-//        var order = paymentRepository.findTopByOrderIdOrderByCreatedAtDesc(orderId);
-//        if (order.isEmpty()) {
-//            log.warn("Nenhum pedido encontrado para orderId={}. Encerrando processamento.", orderId);
-//            return;
-//        }
-
         var payment = Payment.createPending(orderId, amount, method);
         log.debug("Pagamento pendente criado: {}", payment);
         paymentRepository.save(payment);
@@ -44,7 +38,7 @@ public class PaymentService {
             log.debug("Resposta do gateway: approved={}, transactionId={}", result.approved(), result.transactionId());
 
             if (result.approved()) {
-                payment.isAuthorized();
+                payment.markAuthorized();
                 paymentRepository.save(payment);
                 log.info("Pagamento autorizado e salvo. paymentId={}", payment.getId());
             }
@@ -64,7 +58,7 @@ public class PaymentService {
         } catch (RuntimeException ex) {
             log.error("Erro ao processar pagamento para orderId={}, motivo: {}", orderId, ex.getMessage(), ex);
 
-            payment.isFailed();
+            payment.markFailed();
             paymentRepository.save(payment);
             log.warn("Pagamento marcado como falhado. paymentId={}", payment.getId());
 


### PR DESCRIPTION
## Summary
- add status update helpers to `Payment`
- use new helpers in `PaymentService` and remove obsolete comment block

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68af44440510832098e5281b5072c08d