### PR TITLE
Use UUID for order lookups

### DIFF
--- a/services/order-service/src/main/java/com/rafael/api/controller/OrderController.java
+++ b/services/order-service/src/main/java/com/rafael/api/controller/OrderController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,12 +28,12 @@ public class OrderController {
     @GetMapping
     public ResponseEntity<List<OrderResponse>> getAll() {
         List<OrderResponse> orders = service.getAll();
-        return ResponseEntity.status(HttpStatus.CREATED).body(orders);
+        return ResponseEntity.status(HttpStatus.OK).body(orders);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<OrderResponse> getById(@PathVariable("id") Long id) {
+    public ResponseEntity<OrderResponse> getById(@PathVariable("id") UUID id) {
         OrderResponse order = service.getById(id);
-        return ResponseEntity.status(HttpStatus.CREATED).body(order);
+        return ResponseEntity.status(HttpStatus.OK).body(order);
     }
 }

--- a/services/order-service/src/main/java/com/rafael/domain/repository/OrderRepository.java
+++ b/services/order-service/src/main/java/com/rafael/domain/repository/OrderRepository.java
@@ -3,5 +3,7 @@ package com.rafael.domain.repository;
 import com.rafael.domain.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+import java.util.UUID;
+
+public interface OrderRepository extends JpaRepository<Order, UUID> {
 }

--- a/services/order-service/src/main/java/com/rafael/service/OrderService.java
+++ b/services/order-service/src/main/java/com/rafael/service/OrderService.java
@@ -75,7 +75,7 @@ public class OrderService {
     }
 
     @Transactional(readOnly = true)
-    public OrderResponse getById(Long id) {
+    public OrderResponse getById(UUID id) {
         Order orderResponse = repository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Ordem não encontrada: " + id));
         return new OrderResponse(


### PR DESCRIPTION
## Summary
- return HTTP 200 for `getAll` and `getById` endpoints
- switch `id` parameters from `Long` to `UUID`
- update repository to use `UUID` identifiers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af41af2af0832097365d1a573f8fc3