### PR TITLE
feat(frontend): add Next.js frontend with mock auth and theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+out/

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { AppBar, Toolbar, Typography, Button } from '@mui/material';
+import ThemeToggle from '../../components/ThemeToggle';
+import { useAuth } from '../../context/AuthContext';
+import { useRouter } from 'next/navigation';
+import { withAuth } from '../../components/withAuth';
+
+function DashboardPage() {
+  const { user, signOut } = useAuth();
+  const router = useRouter();
+
+  return (
+    <div>
+      <AppBar position="static">
+        <Toolbar>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Dashboard
+          </Typography>
+          <ThemeToggle />
+          <Button color="inherit" onClick={() => { signOut(); router.replace('/login'); }}>
+            Sair
+          </Button>
+        </Toolbar>
+      </AppBar>
+      <Typography variant="h4" sx={{ mt: 4, textAlign: 'center' }}>
+        Bem-vindo, {user.name}
+      </Typography>
+    </div>
+  );
+}
+
+export default withAuth(DashboardPage);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,17 @@
+import Providers from './providers';
+import "./globals.css";
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Exemplo Commerce'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="pt-BR">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TextField, Button, Snackbar, Alert, Link, Stack } from '@mui/material';
+import NextLink from 'next/link';
+import { useState } from 'react';
+import PasswordField from '../../components/PasswordField';
+import AuthCard from '../../components/AuthCard';
+import { useAuth } from '../../context/AuthContext';
+import { useRouter } from 'next/navigation';
+import { withGuest } from '../../components/withAuth';
+
+type FormData = z.infer<typeof schema>;
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1)
+});
+
+function LoginPage() {
+  const { register, handleSubmit, formState: { isSubmitting } } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const [snack, setSnack] = useState<{open: boolean; message: string; severity: 'success' | 'error'} | null>(null);
+  const { signIn } = useAuth();
+  const router = useRouter();
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await signIn(data.email, data.password);
+      setSnack({ open: true, message: 'Login realizado', severity: 'success' });
+      router.replace('/dashboard');
+    } catch (e: any) {
+      setSnack({ open: true, message: e.message, severity: 'error' });
+    }
+  };
+
+  return (
+    <AuthCard title="Login">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Stack spacing={2}>
+          <TextField label="Email" {...register('email')} />
+          <PasswordField label="Senha" {...register('password')} />
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Entrando...' : 'Entrar'}
+          </Button>
+          <Link component={NextLink} href="/signup" underline="hover">Criar conta</Link>
+        </Stack>
+      </form>
+      <Snackbar open={snack?.open || false} autoHideDuration={4000} onClose={() => setSnack(null)}>
+        {snack && <Alert severity={snack.severity}>{snack.message}</Alert>}
+      </Snackbar>
+    </AuthCard>
+  );
+}
+
+export default withGuest(LoginPage);

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/login');
+}

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { ReactNode, useMemo } from 'react';
+import { ThemeProvider as MuiThemeProvider, CssBaseline, createTheme } from '@mui/material';
+import { ThemeContextProvider, useThemeContext } from '../context/ThemeContext';
+import { AuthProvider } from '../context/AuthContext';
+
+const ThemeWrapper = ({ children }: { children: ReactNode }) => {
+  const { mode } = useThemeContext();
+  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+  return (
+    <MuiThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MuiThemeProvider>
+  );
+};
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ThemeContextProvider>
+      <AuthProvider>
+        <ThemeWrapper>{children}</ThemeWrapper>
+      </AuthProvider>
+    </ThemeContextProvider>
+  );
+}

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TextField, Button, Snackbar, Alert, Link, Stack } from '@mui/material';
+import NextLink from 'next/link';
+import { useState } from 'react';
+import PasswordField from '../../components/PasswordField';
+import AuthCard from '../../components/AuthCard';
+import { useRouter } from 'next/navigation';
+import * as authService from '../../services/authService';
+import { withGuest } from '../../components/withAuth';
+
+type FormData = z.infer<typeof schema>;
+
+const schema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(6),
+  confirmPassword: z.string().min(6)
+}).refine(data => data.password === data.confirmPassword, {
+  message: 'Senhas diferentes',
+  path: ['confirmPassword']
+});
+
+function SignupPage() {
+  const { register, handleSubmit, formState: { isSubmitting } } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const [snack, setSnack] = useState<{open: boolean; message: string; severity: 'success' | 'error'} | null>(null);
+  const router = useRouter();
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      await authService.signUp({ name: data.name, email: data.email, password: data.password });
+      setSnack({ open: true, message: 'Cadastro realizado', severity: 'success' });
+      router.replace('/login');
+    } catch (e: any) {
+      setSnack({ open: true, message: e.message, severity: 'error' });
+    }
+  };
+
+  return (
+    <AuthCard title="Cadastro">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Stack spacing={2}>
+          <TextField label="Nome" {...register('name')} />
+          <TextField label="Email" {...register('email')} />
+          <PasswordField label="Senha" {...register('password')} />
+          <PasswordField label="Confirmar senha" {...register('confirmPassword')} />
+          <Button type="submit" variant="contained" disabled={isSubmitting}>
+            {isSubmitting ? 'Enviando...' : 'Cadastrar'}
+          </Button>
+          <Link component={NextLink} href="/login" underline="hover">Já tenho conta</Link>
+        </Stack>
+      </form>
+      <Snackbar open={snack?.open || false} autoHideDuration={4000} onClose={() => setSnack(null)}>
+        {snack && <Alert severity={snack.severity}>{snack.message}</Alert>}
+      </Snackbar>
+    </AuthCard>
+  );
+}
+
+export default withGuest(SignupPage);

--- a/frontend/components/AuthCard.tsx
+++ b/frontend/components/AuthCard.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Container, Card, CardContent, Typography } from '@mui/material';
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+}
+
+export default function AuthCard({ title, children }: Props) {
+  return (
+    <Container maxWidth="sm" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
+      <Card sx={{ width: '100%' }}>
+        <CardContent>
+          <Typography variant="h5" component="h1" gutterBottom>
+            {title}
+          </Typography>
+          {children}
+        </CardContent>
+      </Card>
+    </Container>
+  );
+}

--- a/frontend/components/PasswordField.tsx
+++ b/frontend/components/PasswordField.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { TextField, IconButton, InputAdornment, TextFieldProps } from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOff from '@mui/icons-material/VisibilityOff';
+import { useState } from 'react';
+
+export default function PasswordField(props: TextFieldProps) {
+  const [show, setShow] = useState(false);
+  return (
+    <TextField
+      {...props}
+      type={show ? 'text' : 'password'}
+      InputProps={{
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton onClick={() => setShow(!show)} edge="end">
+              {show ? <VisibilityOff /> : <Visibility />}
+            </IconButton>
+          </InputAdornment>
+        )
+      }}
+    />
+  );
+}

--- a/frontend/components/ThemeToggle.tsx
+++ b/frontend/components/ThemeToggle.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { IconButton } from '@mui/material';
+import Brightness4 from '@mui/icons-material/Brightness4';
+import Brightness7 from '@mui/icons-material/Brightness7';
+import { useThemeContext } from '../context/ThemeContext';
+
+export default function ThemeToggle() {
+  const { mode, toggleTheme } = useThemeContext();
+  return (
+    <IconButton color="inherit" onClick={toggleTheme}>
+      {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
+    </IconButton>
+  );
+}

--- a/frontend/components/withAuth.tsx
+++ b/frontend/components/withAuth.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { ComponentType, useEffect } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { useRouter } from 'next/navigation';
+
+export function withAuth<P>(Component: ComponentType<P>) {
+  return function Wrapped(props: P) {
+    const { user } = useAuth();
+    const router = useRouter();
+    useEffect(() => {
+      if (!user) {
+        router.replace('/login');
+      }
+    }, [user, router]);
+    if (!user) return null;
+    return <Component {...props} />;
+  };
+}
+
+export function withGuest<P>(Component: ComponentType<P>) {
+  return function Wrapped(props: P) {
+    const { user } = useAuth();
+    const router = useRouter();
+    useEffect(() => {
+      if (user) {
+        router.replace('/dashboard');
+      }
+    }, [user, router]);
+    if (user) return null;
+    return <Component {...props} />;
+  };
+}

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import * as authService from '../services/authService';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+}
+
+interface AuthContextValue {
+  user: User | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  user: null,
+  signIn: async () => {},
+  signOut: () => {}
+});
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const current = authService.getCurrentUser();
+    if (current) setUser(current.user);
+  }, []);
+
+  const signIn = async (email: string, password: string) => {
+    const result = await authService.signIn(email, password);
+    setUser(result.user);
+  };
+
+  const signOut = () => {
+    authService.signOut();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/frontend/context/ThemeContext.tsx
+++ b/frontend/context/ThemeContext.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+type ThemeMode = 'light' | 'dark';
+
+interface ThemeContextValue {
+  mode: ThemeMode;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  mode: 'light',
+  toggleTheme: () => {}
+});
+
+export const ThemeContextProvider = ({ children }: { children: ReactNode }) => {
+  const [mode, setMode] = useState<ThemeMode>(
+    (typeof window !== 'undefined' && (localStorage.getItem('theme') as ThemeMode)) || 'light'
+  );
+
+  const toggleTheme = () => {
+    const newMode: ThemeMode = mode === 'light' ? 'dark' : 'light';
+    setMode(newMode);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', newMode);
+    }
+  };
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useThemeContext = () => useContext(ThemeContext);

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.4.12",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mui/material": "5.14.4",
+    "@mui/icons-material": "5.14.4",
+    "@emotion/react": "11.11.1",
+    "@emotion/styled": "11.11.0",
+    "react-hook-form": "7.45.1",
+    "zod": "3.21.4",
+    "@hookform/resolvers": "3.1.0"
+  },
+  "devDependencies": {
+    "typescript": "5.2.2",
+    "eslint": "8.44.0",
+    "eslint-config-next": "13.4.12"
+  }
+}

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -1,0 +1,48 @@
+export interface StoredUser {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+}
+
+const USERS_KEY = 'users';
+const USER_KEY = 'current_user';
+const TOKEN_KEY = 'token';
+
+export async function signUp(data: Omit<StoredUser, 'id'>) {
+  const users: StoredUser[] = JSON.parse(localStorage.getItem(USERS_KEY) || '[]');
+  if (users.find(u => u.email === data.email)) {
+    throw new Error('Email já cadastrado');
+  }
+  const newUser: StoredUser = { ...data, id: Date.now().toString() };
+  users.push(newUser);
+  localStorage.setItem(USERS_KEY, JSON.stringify(users));
+  return { user: newUser };
+}
+
+export async function signIn(email: string, password: string) {
+  const users: StoredUser[] = JSON.parse(localStorage.getItem(USERS_KEY) || '[]');
+  const user = users.find(u => u.email === email && u.password === password);
+  if (!user) {
+    throw new Error('Credenciais inválidas');
+  }
+  const token = 'fake-token';
+  localStorage.setItem(USER_KEY, JSON.stringify(user));
+  localStorage.setItem(TOKEN_KEY, token);
+  return { user: { id: user.id, name: user.name, email: user.email }, token };
+}
+
+export function signOut() {
+  localStorage.removeItem(USER_KEY);
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function getCurrentUser() {
+  const token = localStorage.getItem(TOKEN_KEY);
+  const user = localStorage.getItem(USER_KEY);
+  if (token && user) {
+    const { password, ...rest } = JSON.parse(user) as StoredUser;
+    return { token, user: rest };
+  }
+  return null;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js frontend with MUI theming and auth providers
- add mock auth service using localStorage
- implement login, signup and dashboard pages with route guards and reusable UI components

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@emotion%2freact)
- `npm run lint` (fails: sh: 1: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_68af48c2b5b08320b71f80c658dae14b