### PR TITLE
Show validation errors on signup fields

### DIFF
--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -25,7 +25,7 @@ const schema = z.object({
 });
 
 function SignupPage() {
-  const { register, handleSubmit, formState: { isSubmitting } } = useForm<FormData>({ resolver: zodResolver(schema) });
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormData>({ resolver: zodResolver(schema) });
   const [snack, setSnack] = useState<{open: boolean; message: string; severity: 'success' | 'error'} | null>(null);
   const router = useRouter();
 
@@ -43,10 +43,30 @@ function SignupPage() {
     <AuthCard title="Cadastro">
       <form onSubmit={handleSubmit(onSubmit)}>
         <Stack spacing={2}>
-          <TextField label="Nome" {...register('name')} />
-          <TextField label="Email" {...register('email')} />
-          <PasswordField label="Senha" {...register('password')} />
-          <PasswordField label="Confirmar senha" {...register('confirmPassword')} />
+          <TextField
+            label="Nome"
+            error={!!errors.name}
+            helperText={errors.name?.message}
+            {...register('name')}
+          />
+          <TextField
+            label="Email"
+            error={!!errors.email}
+            helperText={errors.email?.message}
+            {...register('email')}
+          />
+          <PasswordField
+            label="Senha"
+            error={!!errors.password}
+            helperText={errors.password?.message}
+            {...register('password')}
+          />
+          <PasswordField
+            label="Confirmar senha"
+            error={!!errors.confirmPassword}
+            helperText={errors.confirmPassword?.message}
+            {...register('confirmPassword')}
+          />
           <Button type="submit" variant="contained" disabled={isSubmitting}>
             {isSubmitting ? 'Enviando...' : 'Cadastrar'}
           </Button>


### PR DESCRIPTION
## Summary
- show validation errors in signup fields by wiring errors from react-hook-form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af59d4ad408320bc120d3f6f42925d