### PR TITLE
feat: add paginated product listing

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,14 +1,30 @@
 'use client';
 
-import { AppBar, Toolbar, Typography, Button } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button, Pagination } from '@mui/material';
 import ThemeToggle from '../../components/ThemeToggle';
 import { useAuth } from '../../context/AuthContext';
 import { useRouter } from 'next/navigation';
 import { withAuth } from '../../components/withAuth';
+import { useEffect, useState } from 'react';
+import { listProducts, Product } from '../../services/productService';
 
 function DashboardPage() {
   const { user, signOut } = useAuth();
   const router = useRouter();
+
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [products, setProducts] = useState<Product[]>([]);
+  const [total, setTotal] = useState(0);
+
+  useEffect(() => {
+    listProducts(pageSize, page * pageSize).then((data) => {
+      setProducts(data.products);
+      setTotal(data.total);
+    });
+  }, [page, pageSize]);
+
+  const pageCount = Math.ceil(total / pageSize);
 
   return (
     <div>
@@ -18,7 +34,13 @@ function DashboardPage() {
             Dashboard
           </Typography>
           <ThemeToggle />
-          <Button color="inherit" onClick={() => { signOut(); router.replace('/login'); }}>
+          <Button
+            color="inherit"
+            onClick={() => {
+              signOut();
+              router.replace('/login');
+            }}
+          >
             Sair
           </Button>
         </Toolbar>
@@ -26,6 +48,17 @@ function DashboardPage() {
       <Typography variant="h4" sx={{ mt: 4, textAlign: 'center' }}>
         Bem-vindo, {user.name}
       </Typography>
+      {products.map((product) => (
+        <Typography key={product.id} sx={{ mt: 2, textAlign: 'center' }}>
+          {product.title}
+        </Typography>
+      ))}
+      <Pagination
+        count={pageCount}
+        page={page + 1}
+        onChange={(_, value) => setPage(value - 1)}
+        sx={{ mt: 4, display: 'flex', justifyContent: 'center' }}
+      />
     </div>
   );
 }

--- a/frontend/services/productService.ts
+++ b/frontend/services/productService.ts
@@ -1,0 +1,19 @@
+export interface Product {
+  id: number;
+  title: string;
+}
+
+export interface ProductResponse {
+  products: Product[];
+  total: number;
+  limit: number;
+  skip: number;
+}
+
+export async function listProducts(limit: number, skip: number): Promise<ProductResponse> {
+  const res = await fetch(`https://dummyjson.com/products?limit=${limit}&skip=${skip}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch products');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- manage local pagination state in dashboard
- send limit and skip to product service
- render Material UI pagination controls

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5b2450a083208e2346c1bc015f7d