### PR TITLE
feat: extract theme and apply branding customizations

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { ReactNode, useMemo } from 'react';
-import { ThemeProvider as MuiThemeProvider, CssBaseline, createTheme } from '@mui/material';
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material';
+import { createAppTheme } from './theme';
 import { ThemeContextProvider, useThemeContext } from '../context/ThemeContext';
 import { AuthProvider } from '../context/AuthContext';
 
 const ThemeWrapper = ({ children }: { children: ReactNode }) => {
   const { mode } = useThemeContext();
-  const theme = useMemo(() => createTheme({ palette: { mode } }), [mode]);
+  const theme = useMemo(() => createAppTheme(mode), [mode]);
   return (
     <MuiThemeProvider theme={theme}>
       <CssBaseline />

--- a/frontend/app/theme.ts
+++ b/frontend/app/theme.ts
@@ -1,0 +1,48 @@
+import { PaletteMode, ThemeOptions, createTheme, responsiveFontSizes } from '@mui/material';
+
+const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
+  palette: {
+    mode,
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#9c27b0',
+    },
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+  },
+  spacing: 8,
+  shape: {
+    borderRadius: 8,
+  },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          textTransform: 'none',
+        },
+      },
+    },
+    MuiCard: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          padding: '16px',
+        },
+      },
+    },
+    MuiAppBar: {
+      styleOverrides: {
+        root: {
+          borderRadius: 8,
+          boxShadow: 'none',
+        },
+      },
+    },
+  },
+});
+
+export const createAppTheme = (mode: PaletteMode) => responsiveFontSizes(createTheme(getDesignTokens(mode)));


### PR DESCRIPTION
## Summary
- move theme generation to dedicated module
- add branding palette, typography, spacing and border radius
- enable responsive fonts and override Button/Card/AppBar styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af69e4272483208822c577cca65143