### PR TITLE
Use cart context for checkout

### DIFF
--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -1,36 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button, List, ListItem, ListItemText, Snackbar, Alert, Typography, Stack } from '@mui/material';
 import { useAuth } from '../../context/AuthContext';
 import { withAuth } from '../../components/withAuth';
 import * as orderService from '../../services/orderService';
-
-interface CartItem {
-  id: number;
-  title: string;
-  price: number;
-  quantity: number;
-}
+import { useCart } from '../../context/CartContext';
 
 function CheckoutPage() {
   const { user } = useAuth();
-  const [items, setItems] = useState<CartItem[]>([]);
+  const { items, clearCart } = useCart();
   const [loading, setLoading] = useState(false);
   const [snack, setSnack] = useState<{open: boolean; message: string; severity: 'success' | 'error'} | null>(null);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('cart');
-      if (stored) {
-        try {
-          setItems(JSON.parse(stored));
-        } catch {
-          setItems([]);
-        }
-      }
-    }
-  }, []);
 
   const handleCheckout = async () => {
     if (!user) return;
@@ -38,12 +19,9 @@ function CheckoutPage() {
     try {
       await orderService.createOrder({
         userId: Number(user.id),
-        products: items.map(i => ({ id: i.id, quantity: i.quantity }))
+        products: items.map(i => ({ id: i.product.id, quantity: i.quantity }))
       });
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('cart');
-      }
-      setItems([]);
+      clearCart();
       setSnack({ open: true, message: 'Pedido realizado com sucesso', severity: 'success' });
     } catch {
       setSnack({ open: true, message: 'Erro ao finalizar pedido', severity: 'error' });
@@ -60,11 +38,11 @@ function CheckoutPage() {
       ) : (
         <>
           <List>
-            {items.map(item => (
-              <ListItem key={item.id}>
+            {items.map(({ product, quantity }) => (
+              <ListItem key={product.id}>
                 <ListItemText
-                  primary={`${item.title} x${item.quantity}`}
-                  secondary={`$${item.price}`}
+                  primary={`${product.title} x${quantity}`}
+                  secondary={`$${product.price}`}
                 />
               </ListItem>
             ))}


### PR DESCRIPTION
## Summary
- replace localStorage cart management with `useCart`
- show cart products from context and clear cart after order

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6589a52083209cd82bf15879ddc2