### PR TITLE
feat: sync cart with localStorage

### DIFF
--- a/frontend/app/checkout/page.tsx
+++ b/frontend/app/checkout/page.tsx
@@ -1,36 +1,17 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Button, List, ListItem, ListItemText, Snackbar, Alert, Typography, Stack } from '@mui/material';
 import { useAuth } from '../../context/AuthContext';
 import { withAuth } from '../../components/withAuth';
 import * as orderService from '../../services/orderService';
-
-interface CartItem {
-  id: number;
-  title: string;
-  price: number;
-  quantity: number;
-}
+import { useCart } from '../../context/CartContext';
 
 function CheckoutPage() {
   const { user } = useAuth();
-  const [items, setItems] = useState<CartItem[]>([]);
+  const { items, clearCart } = useCart();
   const [loading, setLoading] = useState(false);
   const [snack, setSnack] = useState<{open: boolean; message: string; severity: 'success' | 'error'} | null>(null);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const stored = localStorage.getItem('cart');
-      if (stored) {
-        try {
-          setItems(JSON.parse(stored));
-        } catch {
-          setItems([]);
-        }
-      }
-    }
-  }, []);
 
   const handleCheckout = async () => {
     if (!user) return;
@@ -38,12 +19,9 @@ function CheckoutPage() {
     try {
       await orderService.createOrder({
         userId: Number(user.id),
-        products: items.map(i => ({ id: i.id, quantity: i.quantity }))
+        products: items.map(i => ({ id: Number(i.product.id), quantity: i.quantity }))
       });
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('cart');
-      }
-      setItems([]);
+      clearCart();
       setSnack({ open: true, message: 'Pedido realizado com sucesso', severity: 'success' });
     } catch {
       setSnack({ open: true, message: 'Erro ao finalizar pedido', severity: 'error' });
@@ -61,10 +39,10 @@ function CheckoutPage() {
         <>
           <List>
             {items.map(item => (
-              <ListItem key={item.id}>
+              <ListItem key={item.product.id}>
                 <ListItemText
-                  primary={`${item.title} x${item.quantity}`}
-                  secondary={`$${item.price}`}
+                  primary={`${item.product.title} x${item.quantity}`}
+                  secondary={`$${item.product.price}`}
                 />
               </ListItem>
             ))}

--- a/frontend/context/CartContext.tsx
+++ b/frontend/context/CartContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useReducer, useContext, ReactNode } from 'react';
+import { createContext, useReducer, useContext, ReactNode, useEffect } from 'react';
 
 export interface Product {
   id: string;
@@ -32,7 +32,8 @@ const CartContext = createContext<CartContextValue>({
 type CartAction =
   | { type: 'ADD_ITEM'; product: Product }
   | { type: 'REMOVE_ITEM'; id: string }
-  | { type: 'CLEAR_CART' };
+  | { type: 'CLEAR_CART' }
+  | { type: 'SET_ITEMS'; items: CartItem[] };
 
 const cartReducer = (state: CartState, action: CartAction): CartState => {
   switch (action.type) {
@@ -50,6 +51,8 @@ const cartReducer = (state: CartState, action: CartAction): CartState => {
       return { items: state.items.filter(item => item.product.id !== action.id) };
     case 'CLEAR_CART':
       return { items: [] };
+    case 'SET_ITEMS':
+      return { items: action.items };
     default:
       return state;
   }
@@ -61,6 +64,23 @@ export const CartProvider = ({ children }: { children: ReactNode }) => {
   const addItem = (product: Product) => dispatch({ type: 'ADD_ITEM', product });
   const removeItem = (id: string) => dispatch({ type: 'REMOVE_ITEM', id });
   const clearCart = () => dispatch({ type: 'CLEAR_CART' });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = localStorage.getItem('cart');
+    if (stored) {
+      try {
+        dispatch({ type: 'SET_ITEMS', items: JSON.parse(stored) });
+      } catch {
+        /* ignore invalid json */
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem('cart', JSON.stringify(state.items));
+  }, [state.items]);
 
   return (
     <CartContext.Provider value={{ items: state.items, addItem, removeItem, clearCart }}>


### PR DESCRIPTION
## Summary
- initialize cart items from localStorage on mount
- persist cart changes to localStorage
- use CartContext in checkout instead of manual localStorage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af658f6cb883209822133795d82751