### PR TITLE
Use shared header on dashboard and adjust spacing

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,16 +1,14 @@
 'use client';
 
-import { AppBar, Toolbar, Typography, Button, Pagination } from '@mui/material';
-import ThemeToggle from '../../components/ThemeToggle';
+import { Typography, Pagination, Toolbar } from '@mui/material';
+import Header from '../../components/Header';
 import { useAuth } from '../../context/AuthContext';
-import { useRouter } from 'next/navigation';
 import { withAuth } from '../../components/withAuth';
 import { useEffect, useState } from 'react';
 import { fetchProducts, Product } from '../../services/productService';
 
 function DashboardPage() {
-  const { user, signOut } = useAuth();
-  const router = useRouter();
+  const { user } = useAuth();
 
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
@@ -28,23 +26,8 @@ function DashboardPage() {
 
   return (
     <div>
-      <AppBar position="static">
-        <Toolbar>
-          <Typography variant="h6" sx={{ flexGrow: 1 }}>
-            Dashboard
-          </Typography>
-          <ThemeToggle />
-          <Button
-            color="inherit"
-            onClick={() => {
-              signOut();
-              router.replace('/login');
-            }}
-          >
-            Sair
-          </Button>
-        </Toolbar>
-      </AppBar>
+      <Header />
+      <Toolbar />
       <Typography variant="h4" sx={{ mt: 4, textAlign: 'center' }}>
         Bem-vindo, {user.name}
       </Typography>

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -79,7 +79,7 @@ export default function Header() {
           variant="h6"
           component={Link}
           href="/"
-          sx={{ textDecoration: 'none', color: 'inherit', flexGrow: { xs: 0, sm: 1 } }}
+          sx={{ textDecoration: 'none', color: 'inherit', flexGrow: 1 }}
         >
           Exemplo Commerce
         </Typography>


### PR DESCRIPTION
## Summary
- replace dashboard's local AppBar with shared Header component
- offset dashboard content with Toolbar spacer to sit below fixed header
- ensure Header title flexes so ThemeToggle and ShoppingCart don't overlap on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Type error in app/checkout/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68af6e565d1483208bb0cef193ef64d1