### PR TITLE
refactor: extract product card component

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,21 +1,25 @@
 'use client';
 
-import { AppBar, Toolbar, Typography, Button, Pagination } from '@mui/material';
+import { AppBar, Toolbar, Typography, Button, Pagination, Box } from '@mui/material';
 import ThemeToggle from '../../components/ThemeToggle';
 import { useAuth } from '../../context/AuthContext';
+import { useCart } from '../../context/CartContext';
 import { useRouter } from 'next/navigation';
 import { withAuth } from '../../components/withAuth';
 import { useEffect, useState } from 'react';
 import { fetchProducts, Product } from '../../services/productService';
+import ProductCard from '../../components/ProductCard';
 
 function DashboardPage() {
   const { user, signOut } = useAuth();
+  const { addItem } = useCart();
   const router = useRouter();
 
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
   const [products, setProducts] = useState<Product[]>([]);
   const [total, setTotal] = useState(0);
+  const [hovered, setHovered] = useState<number | null>(null);
 
   useEffect(() => {
     fetchProducts({ limit: pageSize, skip: page * pageSize }).then((data) => {
@@ -23,6 +27,15 @@ function DashboardPage() {
       setTotal(data.total);
     });
   }, [page, pageSize]);
+
+  const handleAddToCart = (product: Product) => {
+    addItem({
+      id: String(product.id),
+      title: product.title,
+      price: product.price,
+      thumbnail: product.thumbnail,
+    });
+  };
 
   const pageCount = Math.ceil(total / pageSize);
 
@@ -48,11 +61,31 @@ function DashboardPage() {
       <Typography variant="h4" sx={{ mt: 4, textAlign: 'center' }}>
         Bem-vindo, {user.name}
       </Typography>
-      {products.map((product) => (
-        <Typography key={product.id} sx={{ mt: 2, textAlign: 'center' }}>
-          {product.title}
-        </Typography>
-      ))}
+      <Box
+        sx={{
+          mt: 4,
+          display: 'grid',
+          gap: { xs: 2, md: 3 },
+          gridTemplateColumns: '1fr',
+          containerType: 'inline-size',
+          '@container (min-width: 600px)': {
+            gridTemplateColumns: 'repeat(2, 1fr)',
+          },
+          '@container (min-width: 900px)': {
+            gridTemplateColumns: 'repeat(3, 1fr)',
+          },
+        }}
+      >
+        {products.map((product) => (
+          <ProductCard
+            key={product.id}
+            product={product}
+            hovered={hovered}
+            setHovered={setHovered}
+            onAddToCart={handleAddToCart}
+          />
+        ))}
+      </Box>
       <Pagination
         count={pageCount}
         page={page + 1}

--- a/frontend/app/products/page.tsx
+++ b/frontend/app/products/page.tsx
@@ -2,9 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import {
-  Card,
-  CardContent,
-  Typography,
   Button,
   TextField,
   Stack,
@@ -13,10 +10,8 @@ import {
   InputLabel,
   FormControl,
   Box,
-  Rating,
-  Zoom,
 } from '@mui/material';
-import Image from 'next/image';
+import ProductCard from '../../components/ProductCard';
 import { fetchProducts, fetchCategories, Product } from '../../services/productService';
 import { useCart } from '../../context/CartContext';
 
@@ -148,53 +143,13 @@ export default function ProductsPage() {
         }}
       >
         {products.map((product) => (
-          <Card
+          <ProductCard
             key={product.id}
-            onMouseEnter={() => setHovered(product.id)}
-            onMouseLeave={() => setHovered(null)}
-            sx={{
-              position: 'relative',
-              overflow: 'hidden',
-              transition: 'transform 0.3s, box-shadow 0.3s',
-              boxShadow: hovered === product.id ? 6 : 1,
-              transform: hovered === product.id ? 'translateY(-4px)' : 'none',
-            }}
-          >
-            <Box sx={{ position: 'relative', aspectRatio: '4/3' }}>
-              <Image src={product.thumbnail} alt={product.title} fill style={{ objectFit: 'cover' }} />
-              <Box
-                sx={{
-                  position: 'absolute',
-                  top: 8,
-                  left: 8,
-                  bgcolor: 'primary.main',
-                  color: 'primary.contrastText',
-                  px: 1,
-                  py: 0.5,
-                  borderRadius: 1,
-                  fontWeight: 'bold',
-                }}
-              >
-                {`$${product.price}`}
-              </Box>
-            </Box>
-            <CardContent>
-              <Typography gutterBottom variant="h6" component="div">
-                {product.title}
-              </Typography>
-              <Rating value={product.rating} precision={0.1} readOnly size="small" />
-            </CardContent>
-            <Zoom in={hovered === product.id} unmountOnExit>
-              <Button
-                size="small"
-                variant="contained"
-                onClick={() => handleAddToCart(product)}
-                sx={{ position: 'absolute', bottom: 16, right: 16 }}
-              >
-                Adicionar ao carrinho
-              </Button>
-            </Zoom>
-          </Card>
+            product={product}
+            hovered={hovered}
+            setHovered={setHovered}
+            onAddToCart={handleAddToCart}
+          />
         ))}
       </Box>
 

--- a/frontend/components/ProductCard.tsx
+++ b/frontend/components/ProductCard.tsx
@@ -1,0 +1,62 @@
+import { Card, CardContent, Typography, Button, Box, Rating, Zoom } from '@mui/material';
+import Image from 'next/image';
+import { Product } from '../services/productService';
+import { Dispatch, SetStateAction } from 'react';
+
+interface ProductCardProps {
+  product: Product;
+  hovered: number | null;
+  setHovered: Dispatch<SetStateAction<number | null>>;
+  onAddToCart: (product: Product) => void;
+}
+
+export default function ProductCard({ product, hovered, setHovered, onAddToCart }: ProductCardProps) {
+  return (
+    <Card
+      onMouseEnter={() => setHovered(product.id)}
+      onMouseLeave={() => setHovered(null)}
+      sx={{
+        position: 'relative',
+        overflow: 'hidden',
+        transition: 'transform 0.3s, box-shadow 0.3s',
+        boxShadow: hovered === product.id ? 6 : 1,
+        transform: hovered === product.id ? 'translateY(-4px)' : 'none',
+      }}
+    >
+      <Box sx={{ position: 'relative', aspectRatio: '4/3' }}>
+        <Image src={product.thumbnail} alt={product.title} fill style={{ objectFit: 'cover' }} />
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 8,
+            left: 8,
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            px: 1,
+            py: 0.5,
+            borderRadius: 1,
+            fontWeight: 'bold',
+          }}
+        >
+          {`$${product.price}`}
+        </Box>
+      </Box>
+      <CardContent>
+        <Typography gutterBottom variant="h6" component="div">
+          {product.title}
+        </Typography>
+        <Rating value={product.rating} precision={0.1} readOnly size="small" />
+      </CardContent>
+      <Zoom in={hovered === product.id} unmountOnExit>
+        <Button
+          size="small"
+          variant="contained"
+          onClick={() => onAddToCart(product)}
+          sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        >
+          Adicionar ao carrinho
+        </Button>
+      </Zoom>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- extract common ProductCard component
- replace inline cards on products and dashboard pages
- show dashboard products in responsive grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af6e56bb7c8320a46611eed4992641