### PR TITLE
Allow CDN dummyjson images in Next.js

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -8,6 +8,11 @@ const nextConfig = {
         hostname: 'i.dummyjson.com',
         pathname: '**',
       },
+      {
+        protocol: 'https',
+        hostname: 'cdn.dummyjson.com',
+        pathname: '**',
+      },
     ],
   }
 };


### PR DESCRIPTION
## Summary
- include cdn.dummyjson.com in Next.js image remote patterns

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b043bf5f048320b31d81d18d83402b