### PR TITLE
feat: adopt blue palette across UI

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -38,10 +38,12 @@ p, h1, h2, h3, h4, h5, h6 {
   color-scheme: light dark;
 
   /* Colors */
-  --color-bg: #ffffff;
+  --color-bg: #e3f2fd;
   --color-text: #111111;
-  --color-primary: #0070f3;
-  --color-secondary: #666666;
+  --color-primary: #1565c0;
+  --color-secondary: #64b5f6;
+  --color-primary-light: #64b5f6;
+  --color-primary-dark: #0d47a1;
 
   /* Spacing */
   --space-xs: clamp(0.25rem, 0.23rem + 0.25vw, 0.5rem);
@@ -62,9 +64,11 @@ p, h1, h2, h3, h4, h5, h6 {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --color-bg: #111111;
+    --color-bg: #0d47a1;
     --color-text: #f5f5f5;
-    --color-primary: #3291ff;
-    --color-secondary: #999999;
+    --color-primary: #1565c0;
+    --color-secondary: #64b5f6;
+    --color-primary-light: #64b5f6;
+    --color-primary-dark: #0d47a1;
   }
 }

--- a/frontend/app/theme.ts
+++ b/frontend/app/theme.ts
@@ -4,11 +4,16 @@ const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
   palette: {
     mode,
     primary: {
-      main: '#1976d2',
+      main: '#1565c0',
+      contrastText: '#ffffff',
     },
     secondary: {
-      main: '#9c27b0',
+      main: '#64b5f6',
+      contrastText: '#ffffff',
     },
+    background: mode === 'light'
+      ? { default: '#e3f2fd', paper: '#ffffff' }
+      : { default: '#0d47a1', paper: '#1565c0' },
   },
   typography: {
     fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',

--- a/frontend/components/AuthCard.tsx
+++ b/frontend/components/AuthCard.tsx
@@ -11,7 +11,7 @@ interface Props {
 export default function AuthCard({ title, children }: Props) {
   return (
     <Container maxWidth="sm" sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}>
-      <Card sx={{ width: '100%' }}>
+      <Card sx={{ width: '100%', bgcolor: 'background.paper' }}>
         <CardContent>
           <Typography variant="h5" component="h1" gutterBottom>
             {title}

--- a/frontend/components/ProductCard.tsx
+++ b/frontend/components/ProductCard.tsx
@@ -21,6 +21,7 @@ export default function ProductCard({ product, hovered, setHovered, onAddToCart 
         transition: 'transform 0.3s, box-shadow 0.3s',
         boxShadow: hovered === product.id ? 6 : 1,
         transform: hovered === product.id ? 'translateY(-4px)' : 'none',
+        bgcolor: 'background.paper',
       }}
     >
       <Box sx={{ position: 'relative', aspectRatio: '4/3' }}>
@@ -51,6 +52,7 @@ export default function ProductCard({ product, hovered, setHovered, onAddToCart 
         <Button
           size="small"
           variant="contained"
+          color="primary"
           onClick={() => onAddToCart(product)}
           sx={{ position: 'absolute', bottom: 16, right: 16 }}
         >

--- a/frontend/theme.ts
+++ b/frontend/theme.ts
@@ -5,15 +5,15 @@ export const getDesignTokens = (mode: PaletteMode): ThemeOptions => ({
     mode,
     ...(mode === 'light'
       ? {
-          primary: { main: '#0d47a1' },
-          secondary: { main: '#00695c' },
-          background: { default: '#fafafa', paper: '#ffffff' },
+          primary: { main: '#1565c0', contrastText: '#ffffff' },
+          secondary: { main: '#64b5f6', contrastText: '#ffffff' },
+          background: { default: '#e3f2fd', paper: '#ffffff' },
           text: { primary: '#000000', secondary: '#333333' }
         }
       : {
-          primary: { main: '#90caf9' },
-          secondary: { main: '#80cbc4' },
-          background: { default: '#121212', paper: '#1e1e1e' },
+          primary: { main: '#1565c0', contrastText: '#ffffff' },
+          secondary: { main: '#64b5f6', contrastText: '#ffffff' },
+          background: { default: '#0d47a1', paper: '#1565c0' },
           text: { primary: '#ffffff', secondary: '#e0e0e0' }
         })
   }


### PR DESCRIPTION
## Summary
- switch MUI theme to blue-based primary and secondary colors with white contrast text
- introduce blue CSS variables and lighten secondary color
- ensure cards use white backgrounds and interactive elements leverage the new palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04592a1f88320a334f8a41d20368d